### PR TITLE
Md 145 add digital twin

### DIFF
--- a/frontend/src/app/components/addTwin.tsx
+++ b/frontend/src/app/components/addTwin.tsx
@@ -1,87 +1,81 @@
 'use client'
 
-import React from "react";
+import React, { useState } from "react";
 import {Card, CardHeader, CardBody, Divider, Input, Button} from "@nextui-org/react";
 import {Select, SelectSection, SelectItem} from "@nextui-org/react";
 import { XMarkIcon } from '@heroicons/react/24/outline';
 
 export default function AddTwin() {
+  const [isCardVisible, setIsCardVisible] = useState(true);
+  const hideCard = () => setIsCardVisible(false);
+  /* const saveCard = () => make an API call */
 
+  if (!isCardVisible) return null;
   
-    return (
-      <Card className="max-w-[600px]" style={{ height: 'auto', minHeight: '500px' }}>
+  return (
+    <Card className="max-w-[600px]" style={{ height: 'auto', minHeight: '500px' }}>
       <CardHeader className="flex justify-between items-center">
-            <div className="flex flex-col">
-              <p className="text-md text-2xl">Add new digital twin</p>
-              <p className="text-large">Digital twin details</p>
-            </div>
-            <Button isIconOnly>
-              <XMarkIcon />
-            </Button>
-
-          </CardHeader>
-          <Divider/>
-          
+        <div className="flex flex-col">
+          <p className="text-md text-2xl">Add new digital twin</p>
+          <p className="text-large">Digital twin details</p>
+        </div>
+        <Button isIconOnly onPress={hideCard}>
+          <XMarkIcon />
+        </Button>
+      </CardHeader>
+      <Divider />
       <CardBody className="flex flex-col justify-between h-full">
-      <div className="flex w-full flex-wrap md:flex-nowrap gap-4" style={{marginTop: '50px'}}>
-            <Input
-              isRequired
-              labelPlacement="outside"
-              type="assetID"
-              placeholder="Asset Identifier"
-              label="AssetID"
-              className="max-w-xs"
-            />
-            <Select 
-              isRequired
-              /* Legge til items={floor} når du skal dynamisk hente */
-              labelPlacement="outside"
-              label="Floor"
-              placeholder="Select a floor" 
-              className="max-w-xs" 
-            >
-              {
-                <SelectItem key={""}>
-                  Test
-                </SelectItem>
-              }
-              </Select>
-              <Select 
-              isRequired
-              labelPlacement="outside"
-              label="Section"
-              placeholder="Select a section" 
-              className="max-w-xs" 
-              >
-              {
-                <SelectItem key={""}>
-                  Test
-                </SelectItem>
-              }
-              </Select>
-          </div>
-          <div className="mt-4">
+        <div className="flex w-full flex-wrap md:flex-nowrap gap-4" style={{ marginTop: '50px' }}>
+          <Input
+            isRequired
+            labelPlacement="outside"
+            type="assetID"
+            placeholder="Asset Identifier"
+            label="AssetID"
+            className="max-w-xs"
+          />
+          <Select 
+            isRequired
+            labelPlacement="outside"
+            label="Floor"
+            placeholder="Select a floor" 
+            className="max-w-xs" 
+          >
+            <SelectItem key={""}>
+              Test
+            </SelectItem>
+          </Select>
+          <Select 
+            isRequired
+            labelPlacement="outside"
+            label="Section"
+            placeholder="Select a section" 
+            className="max-w-xs" 
+          >
+            <SelectItem key={""}>
+              Test
+            </SelectItem>
+          </Select>
+        </div>
+        <div className="mt-4">
           <Input
             labelPlacement="outside"
             type="notes"
             placeholder="Describe the digital twin"
             label="Notes"
             className="max-w-xs"
-            style={{height:'150px', width: '100%'}} 
-            />
-          </div>
-          <div className="flex justify-end gap-2 mt-4" >
-            <Button size="md">
-              Save
-            </Button>
-            <Button size="md">
-              Cancel
-            </Button> 
-          </div>
-
-          </CardBody>
-  </Card>
-  
+            style={{ height: '150px', width: '100%' }} 
+          />
+        </div>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button size="md">
+            Save
+          </Button>
+          <Button size="md" onPress={hideCard}>
+            Cancel
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
   );
 }
-  /* Legge til items={floor} når du skal dynamisk hente */


### PR DESCRIPTION
Added in new component for adding a digital twin. 
<img width="878" alt="Skjermbilde 2023-11-21 kl  09 35 00" src="https://github.com/Library-Light-Twin-DSD2023-MDU-POLIMI/digitaltwin/assets/89526348/b91e8851-50a4-4a51-9214-3988a4ba4739">

The component is only static now, once the API is up, it will be able to save digital twins and dynamically gather the parameters. 
It is also not styled in the colors of the pictures. This because we are doing different colors, so last styling awaits.