### PR TITLE
Digital Twin Page

### DIFF
--- a/frontend/src/app/digitalTwin/page.tsx
+++ b/frontend/src/app/digitalTwin/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardBody, Button, ButtonGroup, Tooltip } from "@nextu
 import { Cog6ToothIcon, AdjustmentsHorizontalIcon, TrashIcon, FlagIcon, ClockIcon, CalendarDaysIcon, CalendarIcon, WrenchScrewdriverIcon, ArrowTopRightOnSquareIcon,QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { Chip } from "@nextui-org/react";
 
-export default function digitalTwin() {
+export default function DigitalTwin() {
     return <div>
         <div id="container_name_options" className="py-4 px-2">
             <Card >


### PR DESCRIPTION
Added the digital twin page

The UI now looks like this
![Screenshot from 2023-11-25 19-00-13](https://github.com/Library-Light-Twin-DSD2023-MDU-POLIMI/digitaltwin/assets/117713291/9147ca08-abf9-4d18-8401-73613549b834)

This pae can be viewed by navigating to `http://localhost:3000/digitalTwin`
One digital twin card is clicked from dashboard, it should open the digital twin page in a new tab

In the latest values section, I commented last two parameters. Because with the sidebar component it's not enough space to show all the parameteres. 

Also, I added tooltip to parameter (only to illuminance as of now just to show how it works) becuase Janet requested it. 

I added a small icon in front of predicted status which we can use to open a new page with predicted graphs as Janet requested. 